### PR TITLE
No longer patch RF tanks

### DIFF
--- a/GameData/ThunderAerospace/TacLifeSupportMFT/TankDefinitions.cfg
+++ b/GameData/ThunderAerospace/TacLifeSupportMFT/TankDefinitions.cfg
@@ -153,58 +153,7 @@ TANK_DEFINITION
 	}
 }
 
-@TANK_DEFINITION[Default]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks|RealFuels]
-{
-	TANK
-	{
-		name = Food
-		amount = 0.0
-		maxAmount = 0.0
-	}
-	TANK
-	{
-		name = Water
-		amount = 0.0
-		maxAmount = 0.0
-		//mass = 0.00001
-	}
-	TANK
-	{
-		name = Oxygen
-		amount = 0.0
-		maxAmount = 0.0
-		utilization = 221.1347
-		//mass = 0.00001
-		note = (pressurized)
-	}
-	TANK
-	{
-		name = Waste
-		amount = 0.0
-		maxAmount = 0.0
-		fillable = false
-	}
-	TANK
-	{
-		name = WasteWater
-		amount = 0.0
-		maxAmount = 0.0
-		//mass = 0.00001
-		fillable = false
-	}
-	TANK
-	{
-		name = CarbonDioxide
-		amount = 0.0
-		maxAmount = 0.0
-		utilization = 476.2173
-		//mass = 0.00001
-		note = (pressurized)
-		fillable = false
-	}
-}
-
-@TANK_DEFINITION[ServiceModule]:FOR[TacLifeSupport]:NEEDS[RealFuels]
+@TANK_DEFINITION[Default]:FOR[TacLifeSupport]:NEEDS[modularFuelTanks]
 {
 	TANK
 	{


### PR DESCRIPTION
RF v10, since it uses CRP, comes out of the box with support for these resources, and thus its tanks don't need to be patched.